### PR TITLE
Feat/mem hard envelope

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cry0",
-  "version": "0.1.0-alpha.1",
+  "version": "0.2.0-alpha.1",
   "description": "A lightweight CLI for generating cold wallets, managing keys, and signing cryptocurrency transactions offline across multiple blockchains.",
   "main": "dist/index.mjs",
   "bin": {

--- a/src/crypto/aes.mts
+++ b/src/crypto/aes.mts
@@ -1,25 +1,37 @@
 import crypto from 'crypto'
 
-export interface Aes256GcmEncrypted {
+export type KdfParams = { name: 'scrypt'; N: number; r: number; p: number; keyLength: number }
+export interface CipherParams {
+  name: 'aes-256-gcm'
+  keyLength: number
+}
+
+export interface EncryptedEnvelopeV1 {
+  version: 1
+  kdf: KdfParams
+  cipher: CipherParams
   salt: string
   iv: string
   tag: string
   ciphertext: string
 }
 
-export async function aesEncrypt(
-  content: string, passphrase: string,
-): Promise<Aes256GcmEncrypted> {
+const DEFAULT_SCRYPT: KdfParams = { name: 'scrypt', N: 1 << 15, r: 8, p: 1, keyLength: 32 }
+const DEFAULT_CIPHER: CipherParams = { name: 'aes-256-gcm', keyLength: 32 }
 
+export async function aesEncrypt(content: string, passphrase: string): Promise<EncryptedEnvelopeV1> {
   const iv = crypto.randomBytes(12)
   const salt = crypto.randomBytes(16)
-  const key = await deriveKeyFromPassword(passphrase, salt)
+  const key = await deriveKey(passphrase, salt, DEFAULT_SCRYPT)
 
   const cipher = crypto.createCipheriv('aes-256-gcm', key, iv)
   const encrypted = Buffer.concat([cipher.update(content, 'utf8'), cipher.final()])
   const authTag = cipher.getAuthTag()
 
   return {
+    version: 1,
+    kdf: DEFAULT_SCRYPT,
+    cipher: DEFAULT_CIPHER,
     salt: salt.toString('hex'),
     iv: iv.toString('hex'),
     tag: authTag.toString('hex'),
@@ -27,14 +39,14 @@ export async function aesEncrypt(
   }
 }
 
-export async function aesDecrypt(
-  encrypted: { salt: string; iv: string; tag: string, ciphertext: string },
-  passphrase: string,
-): Promise<string> {
+export async function aesDecrypt(encrypted: unknown, passphrase: string): Promise<string> {
+  if (!isEnvelopeV1(encrypted)) {
+    throw new Error('Unsupported encrypted envelope format')
+  }
+
   const iv = Buffer.from(encrypted.iv, 'hex')
   const salt = Buffer.from(encrypted.salt, 'hex')
-  const key = await deriveKeyFromPassword(passphrase, salt)
-
+  const key = await deriveKey(passphrase, salt, encrypted.kdf)
   const ciphertext = Buffer.from(encrypted.ciphertext, 'hex')
   const authTag = Buffer.from(encrypted.tag, 'hex')
 
@@ -44,14 +56,19 @@ export async function aesDecrypt(
   return decrypted.toString('utf8')
 }
 
-export async function deriveKeyFromPassword(password: string, salt: Buffer): Promise<Buffer> {
+export async function deriveKey(password: string, salt: Buffer, kdf: KdfParams): Promise<Buffer> {
+  const requiredMem = kdf.N * 128 * kdf.r
+  const maxmem = Math.max(64 * 1024 * 1024, requiredMem * 2)
   return new Promise((resolve, reject) => {
-    const iterations = 100_000
-    const keyLength = 32
-    const digest = 'sha256'
-    crypto.pbkdf2(password, salt, iterations, keyLength, digest, (err, derivedKey) => {
+    crypto.scrypt(password, salt, kdf.keyLength, { N: kdf.N, r: kdf.r, p: kdf.p, maxmem }, (err, derivedKey) => {
       if (err) return reject(err)
-      resolve(derivedKey)
+      resolve(derivedKey as Buffer)
     })
   })
+}
+
+export function isEnvelopeV1(v: unknown): v is EncryptedEnvelopeV1 {
+  return typeof v === 'object' && v !== null
+    && (v as any).version === 1 && typeof (v as any).kdf === 'object' && typeof (v as any).cipher === 'object'
+    && 'ciphertext' in v && 'salt' in v && 'iv' in v && 'tag' in v
 }

--- a/src/error/cli-error.mts
+++ b/src/error/cli-error.mts
@@ -1,20 +1,17 @@
 export class CliError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'CliError';
+  constructor(message: string, error?: unknown) {
+    super(message, { cause: error instanceof Error ? error : undefined })
   }
 }
 
 export class CliInternalError extends CliError {
-  constructor(message: string) {
-    super(message);
-    this.name = 'CliInternalError';
+  constructor(message: string, error?: unknown) {
+    super(message, error)
   }
 }
 
 export class CliParameterError extends CliError {
-  constructor(message: string) {
-    super(message);
-    this.name = 'CliParameterError';
+  constructor(message: string, error?: unknown) {
+    super(message, error)
   }
 }

--- a/src/persistence/storage.mts
+++ b/src/persistence/storage.mts
@@ -1,7 +1,7 @@
 import fs from 'fs/promises'
 import path from 'path'
 import { printer } from '../cli/output/index.mjs'
-import { Aes256GcmEncrypted, aesDecrypt, aesEncrypt } from '../crypto/aes.mjs'
+import { aesDecrypt, aesEncrypt } from '../crypto/aes.mjs'
 import { CliParameterError } from '../error/cli-error.mjs'
 
 export interface Storage<
@@ -31,19 +31,22 @@ export class EncryptedUserHomeJsonStorage<
     await this.walk(storageRoot, async file => {
       const key = path.basename(file, '.json')
       try {
-        let content = JSON.parse((await fs.readFile(file, 'utf-8')))
-        if (isCrypted(content)) {
+        const raw = JSON.parse((await fs.readFile(file, 'utf-8')))
+        if (isCrypted(raw)) {
           if (!this.passphrase) {
             throw new CliParameterError('Passphrase is required')
           }
 
-          content = JSON.parse(await decrypt(content, this.passphrase))
+          const decrypted = await aesDecrypt(raw, this.passphrase)
+          const content = JSON.parse(decrypted)
+          data[key as Keys] = content
+          return;
         }
 
-        data[key as Keys] = content
+        data[key as Keys] = raw
       } catch (err) {
-        printer.debug(`Storage: class UserHomeJsonStorage: Error loading data for key ${key}`)
-        throw err
+        printer.debug(`Storage: class EncryptedUserHomeJsonStorage: Error loading data for key ${key}: ${(err as any)?.message ?? 'unknown error'}`)
+        throw new CliParameterError((err as any)?.message ?? 'unknown error')
       }
     })
 
@@ -183,18 +186,9 @@ const getUserHome = () => {
   throw new Error('Could not find home directory from environment variables')
 }
 
-async function decrypt(content: Aes256GcmEncrypted, passphrase: string): Promise<string> {
-  try {
-    return await aesDecrypt(content, passphrase)
-  } catch (e) {
-    throw new CliParameterError('The passphrase is incorrect')
-  }
-}
-
-function isCrypted(content: unknown): content is Aes256GcmEncrypted {
+function isCrypted(content: unknown): boolean {
   if (content === undefined || content === null) {
     return false
   }
-  return typeof content === 'object'
-    && 'ciphertext' in content && 'salt' in content && 'iv' in content && 'tag' in content
+  return typeof content === 'object' && 'ciphertext' in content
 }


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add versioned encrypted envelope (v1)

- Switch PBKDF2 to scrypt KDF

- Improve CLI error propagation with causes

- Storage decryption flow and logging refined


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["aes.mts: scrypt KDF + envelope v1"] -- "used by" --> B["storage.mts: decrypt & detect"]
  B -- "errors wrapped" --> C["cli-error.mts: cause support"]
  D["package.json: version bump"] -- "reflects" --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Version bump for new crypto format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

- Bump version to 0.2.0-alpha.1


</details>


  </td>
  <td><a href="https://github.com/Drincann/cry0/pull/2/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>aes.mts</strong><dd><code>Scrypt KDF and metadata encryption envelope</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/crypto/aes.mts

<ul><li>Introduce versioned envelope <code>EncryptedEnvelopeV1</code><br> <li> Replace PBKDF2 with scrypt KDF defaults<br> <li> Add <code>deriveKey</code> with scrypt and <code>isEnvelopeV1</code><br> <li> Update encrypt/decrypt to use metadata and validation</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/cry0/pull/2/files#diff-8778a33751aca819084a0e1bfebb53e4eb6c3fc26f9cd5759195785ecaed705a">+34/-17</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>storage.mts</strong><dd><code>Storage adapted to envelope and better errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/persistence/storage.mts

<ul><li>Use new <code>aesDecrypt</code> envelope API<br> <li> Detect encrypted JSON via <code>ciphertext</code> key<br> <li> Improve debug logs and wrap errors as <code>CliParameterError</code><br> <li> Remove PBKDF2-specific types and helper</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/cry0/pull/2/files#diff-48bbfeed29fa79c7dfd8416701165fa52ba57c044c4a596661ebc4e20f45dcb1">+12/-18</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cli-error.mts</strong><dd><code>Propagate underlying error as cause</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/error/cli-error.mts

<ul><li>Accept optional error cause in constructors<br> <li> Set <code>cause</code> when provided for all CLI errors</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/cry0/pull/2/files#diff-e4d1a8124ac695afd6d9f2ca6f08e70116893360c9025548151041097d05985d">+12/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

