### PR TITLE
feat: support p2pkh/p2sh/segwit/taproot address in sign command & bump version to 0.2.1-alpha.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cry0",
-  "version": "0.2.0-alpha.4",
+  "version": "0.2.1-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cry0",
-      "version": "0.2.0-alpha.4",
+      "version": "0.2.1-alpha.1",
       "license": "ISC",
       "dependencies": {
         "@ethereumjs/util": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cry0",
-  "version": "0.2.0-alpha.4",
+  "version": "0.2.1-alpha.1",
   "description": "A lightweight CLI for generating cold wallets, managing keys, and signing cryptocurrency transactions offline across multiple blockchains.",
   "main": "dist/index.mjs",
   "bin": {

--- a/src/utils/validator.mts
+++ b/src/utils/validator.mts
@@ -1,6 +1,10 @@
 import { hexSha256 } from "../crypto/hash.mjs";
 import { CliParameterError } from "../error/cli-error.mjs";
 import { bech32 } from 'bech32'
+import * as bitcoin from 'bitcoinjs-lib';
+import * as ecc from 'tiny-secp256k1';
+
+bitcoin.initEccLib(ecc);
 
 export async function checkHash(saved: string | undefined, provided: string) {
   if (typeof saved !== 'string' || typeof provided !== 'string') {
@@ -34,15 +38,22 @@ export function isNotValidBtcAddressOrRef(address?: unknown): boolean {
     return false
   }
 
-  if (!address.startsWith('bc1') && !address.startsWith('tb1') || address.length !== 42) {
-    return true
+  try {
+    bitcoin.address.toOutputScript(address, bitcoin.networks.bitcoin)
+    return false
+  } catch (e) {
+    try {
+      bitcoin.address.toOutputScript(address, bitcoin.networks.testnet)
+      return false
+    } catch (e2) {
+      try {
+        bitcoin.address.toOutputScript(address, bitcoin.networks.regtest)
+        return false
+      } catch (e3) {
+        return true
+      }
+    }
   }
-
-  if (isNotValidBech32(address)) {
-    return true
-  }
-
-  return false
 }
 
 export function isNotValidEthAddress(address?: unknown): boolean {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Validate BTC addresses via `bitcoinjs-lib`

- Support mainnet, testnet, regtest parsing

- Initialize ECC backend for address scripts

- Bump package version to `0.2.1-alpha.1`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  cli["CLI sign/validate inputs"]
  validator["`isNotValidBtcAddressOrRef()`"]
  btcjs["`bitcoin.address.toOutputScript()`"]
  nets["Bitcoin networks: mainnet/testnet/regtest"]
  result["Valid/invalid BTC address"]
  cli -- "passes address" --> validator
  validator -- "parse as output script" --> btcjs
  btcjs -- "try networks sequentially" --> nets
  nets -- "success/failure" --> result
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Bump package version for new release</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

- Update `version` to `0.2.1-alpha.1`


</details>


  </td>
  <td><a href="https://github.com/Drincann/cry0/pull/5/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>validator.mts</strong><dd><code>Broaden Bitcoin address validation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/utils/validator.mts

<ul><li>Add <code>bitcoinjs-lib</code> and <code>tiny-secp256k1</code> imports<br> <li> Initialize ECC via <code>bitcoin.initEccLib(ecc)</code><br> <li> Replace bech32-only checks with <code>toOutputScript</code><br> <li> Validate against bitcoin/testnet/regtest networks</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/cry0/pull/5/files#diff-951cbfa321fb069c30877598d4f25585e94305d1c32fdd3ba0f7b30b0064576e">+19/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

