### PR TITLE
feat: storage location prompt

### DIFF
--- a/src/cli/commands/wallet/create.mts
+++ b/src/cli/commands/wallet/create.mts
@@ -1,5 +1,8 @@
 import { Command } from 'commander';
 import { repositories as repos } from '../../../persistence/repository.mjs';
+import { getStorageRoot } from '../../../persistence/storage.mjs';
+import path from 'path';
+import os from 'os';
 import { CliParameterError } from '../../../error/cli-error.mjs';
 import { printer } from '../../output/index.mjs';
 import * as mnemonicUtil from '../../../crypto/mnemonic.mjs'
@@ -56,14 +59,26 @@ export const walletCreateCommand = new Command()
         return;
       }
 
-      printer.info(`Wallet '${wallet.alias}' created!`)
+      const walletFile = path.join(getStorageRoot(), 'wallets.json')
       repos.wallet.save(await wallet.serialize())
+      printer.info(`Wallet '${wallet.alias}' created and saved to ${replaceHomeToTilde(walletFile)} (Encrypted with AES-256-GCM)`)
     } catch (e: unknown) {
       if (e instanceof CliParameterError) {
         printer.error(e.message)
       }
     }
   })
+
+function replaceHomeToTilde(p: string): string {
+  const home = os.homedir()
+  if(p === home) {
+    return '~'
+  }
+  if (p.startsWith(`${home}${path.sep}`)) {
+    return `~${p.slice(home.length)}`
+  }
+  return p
+}
 
 function toBuffer(bits?: string): Buffer | undefined {
   if (bits == undefined) {

--- a/src/persistence/storage.mts
+++ b/src/persistence/storage.mts
@@ -156,7 +156,7 @@ export class UserHomeJsonStorage<
   }
 }
 
-const getStorageRoot = () => {
+export const getStorageRoot = () => {
   return path.resolve(getUserHome(), '.bitcold')
 }
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Show wallet save location after creation

- Format saved paths with `~`

- Export storage root helper for reuse


___

### Diagram Walkthrough


```mermaid
flowchart LR
  wc["wallet create command"]
  sr["`getStorageRoot()`"]
  fp["path formatter using home dir"]
  msg["creation success message"]
  wc -- "uses" --> sr
  wc -- "formats" --> fp
  sr -- "builds save path for" --> msg
  fp -- "shortens displayed path in" --> msg
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create.mts</strong><dd><code>Show saved wallet path on creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/cli/commands/wallet/create.mts

<ul><li>Import <code>getStorageRoot</code>, <code>path</code>, and <code>os</code><br> <li> Compute saved wallet file path<br> <li> Show save location in success output<br> <li> Add <code>formatPath()</code> to replace home with <code>~</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/bitcold/pull/9/files#diff-197dd55d863d425d14393b15114da254ef18e29afb9634675f39b6c4c49fb8ad">+13/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>storage.mts</strong><dd><code>Export storage root path helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/persistence/storage.mts

<ul><li>Export <code>getStorageRoot()</code> for external reuse<br> <li> Keep storage root resolution logic unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/bitcold/pull/9/files#diff-48bbfeed29fa79c7dfd8416701165fa52ba57c044c4a596661ebc4e20f45dcb1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

