### PR TITLE
Revert "feat: storage location prompt"

### DIFF
--- a/src/cli/commands/wallet/create.mts
+++ b/src/cli/commands/wallet/create.mts
@@ -1,8 +1,5 @@
 import { Command } from 'commander';
 import { repositories as repos } from '../../../persistence/repository.mjs';
-import { getStorageRoot } from '../../../persistence/storage.mjs';
-import path from 'path';
-import os from 'os';
 import { CliParameterError } from '../../../error/cli-error.mjs';
 import { printer } from '../../output/index.mjs';
 import * as mnemonicUtil from '../../../crypto/mnemonic.mjs'
@@ -59,26 +56,14 @@ export const walletCreateCommand = new Command()
         return;
       }
 
-      const walletFile = path.join(getStorageRoot(), 'wallets.json')
+      printer.info(`Wallet '${wallet.alias}' created!`)
       repos.wallet.save(await wallet.serialize())
-      printer.info(`Wallet '${wallet.alias}' created and saved to ${replaceHomeToTilde(walletFile)} (Encrypted with AES-256-GCM)`)
     } catch (e: unknown) {
       if (e instanceof CliParameterError) {
         printer.error(e.message)
       }
     }
   })
-
-function replaceHomeToTilde(p: string): string {
-  const home = os.homedir()
-  if(p === home) {
-    return '~'
-  }
-  if (p.startsWith(`${home}${path.sep}`)) {
-    return `~${p.slice(home.length)}`
-  }
-  return p
-}
 
 function toBuffer(bits?: string): Buffer | undefined {
   if (bits == undefined) {

--- a/src/persistence/storage.mts
+++ b/src/persistence/storage.mts
@@ -156,7 +156,7 @@ export class UserHomeJsonStorage<
   }
 }
 
-export const getStorageRoot = () => {
+const getStorageRoot = () => {
   return path.resolve(getUserHome(), '.bitcold')
 }
 


### PR DESCRIPTION
### **User description**
Reverts Drincann/bitcold#9


___

### **PR Type**
Other


___

### **Description**
- Revert wallet save-location success output

- Remove home-path shortening helper

- Make storage root helper internal


___

### Diagram Walkthrough


```mermaid
flowchart LR
  wc["wallet create command"]
  msg["generic creation message"]
  save["wallet save operation"]
  sr["`getStorageRoot()`"]
  local["module-local helper"]
  wc -- "prints" --> msg
  wc -- "then calls" --> save
  sr -- "is reverted to" --> local
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create.mts</strong><dd><code>Revert wallet creation path display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/cli/commands/wallet/create.mts

<ul><li>Remove <code>getStorageRoot</code>, <code>path</code>, and <code>os</code> imports<br> <li> Replace saved-location message with generic creation output<br> <li> Drop the home-directory-to-<code>~</code> path formatter<br> <li> Keep wallet persistence call after the message</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/bitcold/pull/11/files#diff-197dd55d863d425d14393b15114da254ef18e29afb9634675f39b6c4c49fb8ad">+1/-16</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>storage.mts</strong><dd><code>Make storage root helper private again</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/persistence/storage.mts

<ul><li>Remove the export from <code>getStorageRoot()</code><br> <li> Keep storage root resolution logic module-local</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/bitcold/pull/11/files#diff-48bbfeed29fa79c7dfd8416701165fa52ba57c044c4a596661ebc4e20f45dcb1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

