### PR TITLE
feat: remove sha256 secret

### DIFF
--- a/src/cli/commands/wallet/show.mts
+++ b/src/cli/commands/wallet/show.mts
@@ -2,9 +2,6 @@ import { Command } from 'commander';
 import { Wallet } from '../../../domain/wallet.mjs';
 import { repositories as repos } from '../../../persistence/repository.mjs';
 import { printer } from '../../output/index.mjs';
-import prompts from 'prompts'
-import { WalletData, StoredWalletData } from '../../../domain/types.mjs';
-import { hexSha256 } from '../../../crypto/hash.mjs';
 import { ensureCliLevelSecretInitialized } from '../../../env/index.mjs';
 import { CliError } from '../../../error/cli-error.mjs';
 import { BTC_DERIVATION_PATH_PREFIX } from '../../../crypto/mnemonic.mjs';

--- a/src/crypto/aes.mts
+++ b/src/crypto/aes.mts
@@ -1,5 +1,12 @@
 import crypto from 'crypto'
 
+export class AesAuthenticationError extends Error {
+  constructor() {
+    super('Decryption failed: authentication tag mismatch')
+    this.name = 'AesAuthenticationError'
+  }
+}
+
 export type KdfParams = { name: 'scrypt'; N: number; r: number; p: number; keyLength: number }
 export interface CipherParams {
   name: 'aes-256-gcm'
@@ -52,8 +59,12 @@ export async function aesDecrypt(encrypted: unknown, passphrase: string): Promis
 
   const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv)
   decipher.setAuthTag(authTag)
-  const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()])
-  return decrypted.toString('utf8')
+  try {
+    const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()])
+    return decrypted.toString('utf8')
+  } catch {
+    throw new AesAuthenticationError()
+  }
 }
 
 export async function deriveKey(password: string, salt: Buffer, kdf: KdfParams): Promise<Buffer> {

--- a/src/env/index.mts
+++ b/src/env/index.mts
@@ -1,9 +1,8 @@
 import { Network, networks } from "bitcoinjs-lib";
-import { hexSha256 } from "../crypto/hash.mjs";
 import { repositories } from "../persistence/repository.mjs";
 import { CliParameterError } from "../error/cli-error.mjs";
 import prompts from "prompts";
-import { checkHash, isNotString } from "../utils/validator.mjs";
+import { isNotString } from "../utils/validator.mjs";
 
 const netMappings = {
   'testnet': networks.testnet,
@@ -37,25 +36,26 @@ function emptyToUndefined(value: string | undefined): string | undefined {
 
 export async function ensureCliLevelSecretInitialized() {
   let cliPassphrase = emptyToUndefined(process.env.BITCOLD_PASSPHRASE)
-  const secretSha256 = await repositories.secret.get()
-  if (secretSha256 === undefined) {
+  if (!(await repositories.initialized())) {
     if (cliPassphrase === undefined) {
-      cliPassphrase = await questionUserToCreateCliPassphrase(cliPassphrase);
+      cliPassphrase = await questionUserToCreateCliPassphrase();
     }
-
-    await repositories.secret.set(await hexSha256(cliPassphrase!))
+    await repositories.init(cliPassphrase!)
+    return
   }
 
   if (cliPassphrase === undefined) {
-    cliPassphrase = await questionCliPassphrase(cliPassphrase);
+    cliPassphrase = await questionCliPassphrase();
   }
 
-  await checkHash(await repositories.secret.get(), cliPassphrase);
-
-  await repositories.init(cliPassphrase)
+  await repositories.init(cliPassphrase!)
+  // Passphrase verification happens implicitly: loading encrypted data
+  // with a wrong passphrase will throw CliParameterError('CLI passphrase is incorrect')
+  // due to AES-256-GCM auth tag verification failure.
+  await repositories.wallet.getAllWallets()
 }
 
-async function questionUserToCreateCliPassphrase(cliPassphrase: string | undefined) {
+async function questionUserToCreateCliPassphrase() {
   const { value: passphrase } = await prompts({
     type: 'password',
     name: 'value',
@@ -75,18 +75,17 @@ async function questionUserToCreateCliPassphrase(cliPassphrase: string | undefin
     throw new CliParameterError('Passphrases do not match');
   }
 
-  cliPassphrase = passphrase;
-  return cliPassphrase;
+  return passphrase;
 }
 
-async function questionCliPassphrase(cliPassphrase: string | undefined) {
+async function questionCliPassphrase() {
   const response = await prompts({
     type: 'password',
     name: 'value',
     message: 'Enter a passphrase for the CLI'
   });
 
-  cliPassphrase = response.value;
+  const cliPassphrase = response.value;
   if (isNotString(cliPassphrase)) {
     throw new CliParameterError('CLI passphrase is required');
   }

--- a/src/persistence/repository.mts
+++ b/src/persistence/repository.mts
@@ -1,7 +1,7 @@
-import { EncryptedUserHomeJsonStorage, Storage, UserHomeJsonStorage } from "./storage.mjs"
+import { EncryptedUserHomeJsonStorage } from "./storage.mjs"
 import type { Collections, StoredWalletData } from "../domain/types.mjs"
 
-let storage: Storage<Collections> = new EncryptedUserHomeJsonStorage('');
+let storage: EncryptedUserHomeJsonStorage<Collections> = new EncryptedUserHomeJsonStorage('');
 
 class WalletRepository {
   public async getAllWallets(): Promise<StoredWalletData[]> {
@@ -28,11 +28,11 @@ class WalletRepository {
   }
 
   public async remove(walletAlias: string) {
-    storage.save('wallets', (await storage.load('wallets')).filter(wallet => wallet.alias !== walletAlias))
+    await storage.save('wallets', (await storage.load('wallets')).filter(wallet => wallet.alias !== walletAlias))
   }
 
   public async rename(fromWallet: any, toWallet: any) {
-    storage.save('wallets', (await storage.load('wallets')).map(wallet => {
+    await storage.save('wallets', (await storage.load('wallets')).map(wallet => {
       if (wallet.alias === fromWallet) {
         wallet.alias = toWallet
       }
@@ -41,23 +41,10 @@ class WalletRepository {
   }
 }
 
-class SecretHashRepository {
-  private storage = new UserHomeJsonStorage<{ secret: { hash: string } }>();
-
-  public async set(hash: string) {
-    await this.storage.save('secret', { hash })
-  }
-
-  public async get(): Promise<string | undefined> {
-    return (await this.storage.load('secret'))?.hash
-  }
-}
-
 const walletRepo = new WalletRepository()
-const secretRepo = new SecretHashRepository()
 export const repositories = {
   wallet: walletRepo,
-  secret: secretRepo,
+  initialized: () => storage.initialized(),
   init: async (passphrase: string) => {
     storage = new EncryptedUserHomeJsonStorage(passphrase)
   }

--- a/src/persistence/storage.mts
+++ b/src/persistence/storage.mts
@@ -1,8 +1,8 @@
 import fs from 'fs/promises'
 import path from 'path'
 import { printer } from '../cli/output/index.mjs'
-import { aesDecrypt, aesEncrypt } from '../crypto/aes.mjs'
-import { CliInternalError } from '../error/cli-error.mjs'
+import { AesAuthenticationError, aesDecrypt, aesEncrypt } from '../crypto/aes.mjs'
+import { CliInternalError, CliParameterError } from '../error/cli-error.mjs'
 
 export interface Storage<
   DataTypes extends { [key in Keys]: any },
@@ -23,6 +23,13 @@ export class EncryptedUserHomeJsonStorage<
     this.passphrase = passphrase
   }
 
+  public async initialized(): Promise<boolean> {
+    const storageRoot = getStorageRoot()
+    await createIfNotExists(storageRoot)
+    const files = await fs.readdir(storageRoot)
+    return files.some(f => f.endsWith('.json'))
+  }
+
   private async loadAllAndDecrypt(): Promise<DataTypes> {
     const storageRoot = getStorageRoot()
     await createIfNotExists(storageRoot)
@@ -32,21 +39,24 @@ export class EncryptedUserHomeJsonStorage<
       const key = path.basename(file, '.json')
       try {
         const raw = JSON.parse((await fs.readFile(file, 'utf-8')))
-        if (isCrypted(raw)) {
-          if (!this.passphrase) {
-            throw new CliInternalError('Passphrase is required')
-          }
-
-          const decrypted = await aesDecrypt(raw, this.passphrase)
-          const content = JSON.parse(decrypted)
-          data[key as Keys] = content
-          return;
+        if (!isCrypted(raw)) {
+          printer.debug(`Storage: Skipping non-encrypted file ${file}`)
+          return
         }
 
-        data[key as Keys] = raw
+        if (!this.passphrase) {
+          throw new CliInternalError('Passphrase is required')
+        }
+
+        const decrypted = await aesDecrypt(raw, this.passphrase)
+        const content = JSON.parse(decrypted)
+        data[key as Keys] = content
       } catch (err) {
+        if (err instanceof AesAuthenticationError) {
+          throw new CliParameterError('CLI passphrase is incorrect')
+        }
         printer.debug(`Storage: class EncryptedUserHomeJsonStorage: Error loading data for key ${key}: ${(err as any)?.message ?? 'unknown error'}`)
-        throw new CliInternalError(`Error loading data for key: ${key}`, err)
+        throw new CliInternalError(`${key}.json is not a valid encrypted store, repair the file or restore from backup.`, err)
       }
     })
 
@@ -81,70 +91,7 @@ export class EncryptedUserHomeJsonStorage<
       throw new CliInternalError('Passphrase is required')
     }
 
-    fs.writeFile(file, JSON.stringify(await aesEncrypt(JSON.stringify(data), this.passphrase)))
-  }
-
-  public async load<K extends Keys>(key: K): Promise<DataTypes[K]> {
-    if (!this.cache) {
-      this.cache = await this.loadAllAndDecrypt()
-    }
-
-    return this.cache[key]
-  }
-}
-
-export class UserHomeJsonStorage<
-  DataTypes extends { [key in Keys]: any },
-  Keys extends string = Exclude<keyof DataTypes, symbol | number>
-> implements Storage<DataTypes, Keys> {
-  private cache?: DataTypes
-
-  constructor() { }
-
-  private async loadAllAndDecrypt(): Promise<DataTypes> {
-    const storageRoot = getStorageRoot()
-    await createIfNotExists(storageRoot)
-    const data = {} as DataTypes
-
-    await this.walk(storageRoot, async file => {
-      const key = path.basename(file, '.json')
-      try {
-        data[key as Keys] = JSON.parse((await fs.readFile(file, 'utf-8')))
-      } catch (err) {
-        printer.debug(`Storage: class UserHomeJsonStorage: Error loading data for key ${key}`)
-        throw new CliInternalError(`Error loading data for key: ${key}`, err)
-      }
-    })
-
-    return data
-  }
-
-  private async walk(dir: string, callback: (file: string) => Promise<void>) {
-    const files = await fs.readdir(dir)
-
-    for (const file of files) {
-      const filePath = path.join(dir, file)
-      const stat = await fs.stat(filePath)
-
-      if (stat.isFile()) {
-        await callback(filePath)
-      } else {
-        printer.warn(`Storage: method walk: Skipping directory ${filePath}`)
-      }
-    }
-  }
-
-  public async save<K extends Keys>(key: K, data: DataTypes[K]): Promise<void> {
-    if (!this.cache) {
-      this.cache = await this.loadAllAndDecrypt()
-    }
-
-    this.cache[key] = data
-    const storageRoot = getStorageRoot()
-    await createIfNotExists(storageRoot)
-    const file = path.join(storageRoot, `${key}.json`)
-
-    fs.writeFile(file, JSON.stringify(data))
+    await fs.writeFile(file, JSON.stringify(await aesEncrypt(JSON.stringify(data), this.passphrase)))
   }
 
   public async load<K extends Keys>(key: K): Promise<DataTypes[K]> {
@@ -160,13 +107,16 @@ const getStorageRoot = () => {
   return path.resolve(getUserHome(), '.bitcold')
 }
 
+const STORAGE_DIR_MODE = 0o700
+
 const createIfNotExists = async (dir: string) => {
   try {
-    await fs.mkdir(dir)
+    await fs.mkdir(dir, { mode: STORAGE_DIR_MODE })
   } catch (err) {
     if ((err as any)?.code !== 'EEXIST') {
       throw new CliInternalError(`Error creating directory: ${dir}`, err)
     }
+    await fs.chmod(dir, STORAGE_DIR_MODE)
   }
 
   return dir

--- a/src/utils/validator.mts
+++ b/src/utils/validator.mts
@@ -1,21 +1,8 @@
-import { hexSha256 } from "../crypto/hash.mjs";
-import { CliParameterError } from "../error/cli-error.mjs";
 import { bech32 } from 'bech32'
 import * as bitcoin from 'bitcoinjs-lib';
 import * as ecc from 'tiny-secp256k1';
 
 bitcoin.initEccLib(ecc);
-
-export async function checkHash(saved: string | undefined, provided: string) {
-  if (typeof saved !== 'string' || typeof provided !== 'string') {
-    throw new CliParameterError('CLI passphrase is incorrect');
-  }
-
-  const hash = await hexSha256(provided)
-  if (hash !== saved) {
-    throw new CliParameterError('CLI passphrase is incorrect');
-  }
-}
 
 export function isNotString(value: unknown): value is undefined {
   return typeof value !== 'string';


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Remove stored SHA-256 passphrase secret

- Verify passphrase through encrypted reads

- Add encrypted storage initialization checks

- Await wallet persistence writes correctly


___

### Diagram Walkthrough


```mermaid
flowchart LR
  init["CLI startup"] 
  check["Check encrypted storage initialized"] 
  prompt["Prompt to create or enter passphrase"] 
  repo["Initialize encrypted repository"] 
  verify["Load wallets to verify passphrase"] 
  error["Raise incorrect passphrase error"]

  init -- "starts" --> check
  check -- "not initialized" --> prompt
  check -- "initialized" --> prompt
  prompt -- "provides passphrase" --> repo
  repo -- "reads encrypted data" --> verify
  verify -- "auth failure" --> error
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>show.mts</strong><dd><code>Clean up obsolete wallet show imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/cli/commands/wallet/show.mts

<ul><li>Remove unused prompt and hash imports<br> <li> Keep wallet show using shared secret init</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/bitcold/pull/12/files#diff-426183024af0f3b03185403a18b11f1910b76318441365ae07603c3d5a6ab079">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.mts</strong><dd><code>Rework CLI passphrase initialization flow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/env/index.mts

<ul><li>Replace secret-hash checks with init status<br> <li> Initialize repository on first passphrase setup<br> <li> Verify passphrase by loading encrypted wallets<br> <li> Simplify passphrase prompt helper signatures</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/bitcold/pull/12/files#diff-fbf95c43153f520249880447dc3b552582bdf6f4369077da6f9cc47176522e46">+16/-17</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>storage.mts</strong><dd><code>Harden encrypted storage loading behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/persistence/storage.mts

<ul><li>Add encrypted storage initialization detection<br> <li> Skip non-encrypted files during loading<br> <li> Map AES auth failures to CLI errors<br> <li> Enforce secure storage directory permissions</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/bitcold/pull/12/files#diff-48bbfeed29fa79c7dfd8416701165fa52ba57c044c4a596661ebc4e20f45dcb1">+26/-76</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>repository.mts</strong><dd><code>Simplify repository storage and init access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/persistence/repository.mts

<ul><li>Restrict storage to encrypted implementation<br> <li> Expose <code>initialized()</code> through repositories facade<br> <li> Remove plaintext secret hash repository<br> <li> Await wallet <code>remove</code> and <code>rename</code> saves</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/bitcold/pull/12/files#diff-bae58f020f380571fd0dc3d24ba0b62768c55594a6916e55a3f4750dbec6f5e8">+5/-18</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>validator.mts</strong><dd><code>Drop unused hash-based passphrase validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/utils/validator.mts

<ul><li>Remove obsolete passphrase hash validator<br> <li> Keep only generic string type check</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/bitcold/pull/12/files#diff-951cbfa321fb069c30877598d4f25585e94305d1c32fdd3ba0f7b30b0064576e">+0/-13</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

