### PR TITLE
feat: remove passphrase persistence for plausible deniability

### DIFF
--- a/src/cli/commands/wallet/list.mts
+++ b/src/cli/commands/wallet/list.mts
@@ -1,11 +1,9 @@
 import { Command } from 'commander';
-import { Wallet } from '../../../domain/wallet.mjs';
 import { repositories as repos } from '../../../persistence/repository.mjs';
 import { printer } from '../../output/index.mjs';
 import { ensureCliLevelSecretInitialized } from '../../../env/index.mjs';
 import { StoredWalletData } from '../../../domain/types.mjs';
 import { CliError } from '../../../error/cli-error.mjs';
-import { accountSummary } from '../../../utils/display.mjs';
 
 export const walletListCommand = new Command()
   .name('list')
@@ -22,7 +20,7 @@ export const walletListCommand = new Command()
 
       for (let i = 0; i < walletsData.length; i++) {
         const walletData = walletsData[i];
-        printer.info(`${i}.${walletData.alias} [${await summary(walletData)}]`);
+        printer.info(`${i}.${walletData.alias} [${summary(walletData)}]`);
       }
     } catch (e: unknown) {
       if (e instanceof CliError) {
@@ -31,8 +29,6 @@ export const walletListCommand = new Command()
     }
   })
 
-async function summary(walletData: StoredWalletData) {
-  return walletData.mnemonic.hasPassphrase
-    ? 'locked'
-    : accountSummary((await Wallet.from(walletData)).accounts);
+function summary(walletData: StoredWalletData) {
+  return walletData.accounts.map(a => a.alias).join(', ')
 }

--- a/src/domain/types.mts
+++ b/src/domain/types.mts
@@ -11,8 +11,6 @@ export interface Mnemonic {
 
 export interface StoredMnemonic {
   words: string
-  hasPassphrase: boolean
-  passphraseSha256?: string
 }
 
 export interface Collections {

--- a/src/domain/wallet.mts
+++ b/src/domain/wallet.mts
@@ -2,7 +2,6 @@ import type { WalletData, StoredWalletData } from "./types.mjs";
 import { identity, toMap } from "../utils/fp.mjs";
 import { Account } from "./account.mjs";
 import { Mnemonic } from "./types.mjs";
-import { hexSha256 } from "../crypto/hash.mjs";
 import prompts from "prompts";
 import { CliParameterError } from "../error/cli-error.mjs";
 import { printer } from "../cli/output/index.mjs";
@@ -55,29 +54,20 @@ export class Wallet {
   }
 
   public static async from(data: StoredWalletData): Promise<Wallet> {
+    const result = await prompts({
+      type: 'password',
+      name: 'value',
+      message: 'Enter the wallet "' + data.alias + '" mnemonic passphrase (leave blank to skip)'
+    })
+
+    const passphrase = typeof result.value === 'string' && result.value.length > 0 ? result.value : undefined
+
     const walletData: WalletData = {
       ...data,
       mnemonic: {
-        ...data.mnemonic,
-        passphrase: undefined
+        words: data.mnemonic.words,
+        passphrase: passphrase
       }
-    }
-
-    if (data.mnemonic.hasPassphrase) {
-      const result = await prompts({
-        type: 'password',
-        name: 'value',
-        message: 'Enter the wallet "' + data.alias + '" mnemonic passphrase'
-      })
-      if (typeof result.value !== 'string' || result.value.length === 0) {
-        throw new CliParameterError('Passphrase is required');
-      }
-
-      if (!await hashMatches(data.mnemonic.passphraseSha256, result.value)) {
-        throw new CliParameterError('Passphrase is incorrect');
-      }
-
-      walletData.mnemonic.passphrase = result.value
     }
 
     return new Wallet(
@@ -91,31 +81,11 @@ export class Wallet {
     return {
       alias: this.alias,
       mnemonic: {
-        hasPassphrase: isNonEmptyString(this.mnemonic.passphrase),
-        passphraseSha256: this.mnemonic.passphrase ? await hexSha256(this.mnemonic.passphrase) : undefined,
         words: this.mnemonic.words,
       },
       accounts: [...this.accounts.values()].map(account => account.serialize())
     }
   }
-}
-
-function assignPassphrase(walletData: StoredWalletData, value: string): WalletData {
-  return {
-    ...walletData,
-    mnemonic: {
-      ...walletData.mnemonic,
-      passphrase: value
-    }
-  }
-}
-
-async function hashMatches(passphraseSha256: string | undefined, value: string): Promise<boolean> {
-  return await hexSha256(value) === passphraseSha256;
-}
-
-function isNonEmptyString(passphrase: string | undefined): boolean {
-  return typeof passphrase === 'string' && passphrase.length > 0;
 }
 
 /** Smallest non-negative integer not used by any account (fills gaps before extending). */


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Stop storing mnemonic passphrase metadata

- Prompt optional passphrase on wallet load

- List wallets from stored account aliases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  store["Stored wallet mnemonic data"]
  load["Wallet.from optional passphrase prompt"]
  list["wallet list shows account aliases"]

  store -- "drops passphrase flags and hashes" --> load
  store -- "reads stored accounts directly" --> list
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>list.mts</strong><dd><code>Simplify wallet listing from stored accounts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/cli/commands/wallet/list.mts

<ul><li>Remove async wallet summary generation<br> <li> Print stored account aliases directly<br> <li> Avoid loading wallets during listing</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/bitcold/pull/18/files#diff-572ad7ae45607115fb3ec4dfc2a4247daefbb2f43abae76bab7eb82d309eb2ff">+3/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>types.mts</strong><dd><code>Shrink stored mnemonic passphrase metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/domain/types.mts

<ul><li>Remove <code>hasPassphrase</code> from <code>StoredMnemonic</code><br> <li> Remove persisted <code>passphraseSha256</code> field<br> <li> Keep only mnemonic words in storage</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/bitcold/pull/18/files#diff-1eb13d2921465aedf8c0a123cd5f5036333836da6f15e6b29e1671b467958e75">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>wallet.mts</strong><dd><code>Drop passphrase persistence and verification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/domain/wallet.mts

<ul><li>Always prompt for an optional passphrase<br> <li> Stop requiring or validating saved passphrases<br> <li> Serialize wallets without passphrase state<br> <li> Remove hashing and passphrase helper logic</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/bitcold/pull/18/files#diff-4e51445f7140665dfd60e1a5aa87e0fc3580e4b8851d09b166b5a5a41a8e3c0f">+10/-40</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

