### PR TITLE
refactor: unify initial account alias to 'account_0'

### DIFF
--- a/src/cli/commands/wallet/create.mts
+++ b/src/cli/commands/wallet/create.mts
@@ -46,7 +46,7 @@ export const walletCreateCommand = new Command()
         passphrase: opts.passphrase
       }
 
-      const wallet: Wallet = Wallet.generateWithDefaultAccount(walletName, mnemonic)
+      const wallet: Wallet = Wallet.generateWithInitialAccount(walletName, mnemonic)
 
       if (opts.showMnemonic) {
         printer.warn('warn: mnemonic is shown in the console, please keep it safe')

--- a/src/domain/wallet.mts
+++ b/src/domain/wallet.mts
@@ -18,8 +18,8 @@ export class Wallet {
     this.accounts = toMap(accounts, account => account.alias, identity())
   }
 
-  public static generateWithDefaultAccount(alias: string, mnemonic: Mnemonic) {
-    return new Wallet(alias, mnemonic, [new Account(mnemonic, 0, 'default')])
+  public static generateWithInitialAccount(alias: string, mnemonic: Mnemonic) {
+    return new Wallet(alias, mnemonic, [new Account(mnemonic, 0, 'account_0')])
   }
 
   public addAccount(accountAlias: string, index?: number): void {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Rename initial wallet account alias

- Update wallet creation to new API


___

### Diagram Walkthrough


```mermaid
flowchart LR
  WC["Wallet create command"]
  WG["Wallet.generateWithInitialAccount"]
  IA["Initial account alias account_0"]
  WC -- "calls" --> WG
  WG -- "creates" --> IA
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create.mts</strong><dd><code>Update CLI wallet creation method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/cli/commands/wallet/create.mts

<ul><li>Replace <code>Wallet.generateWithDefaultAccount</code> call<br> <li> Use <code>Wallet.generateWithInitialAccount</code> during wallet creation<br> <li> Keep wallet generation flow unchanged otherwise</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/bitcold/pull/20/files#diff-197dd55d863d425d14393b15114da254ef18e29afb9634675f39b6c4c49fb8ad">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>wallet.mts</strong><dd><code>Standardize initial account naming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/domain/wallet.mts

<ul><li>Rename factory method to <code>generateWithInitialAccount</code><br> <li> Change initial account alias to <code>account_0</code><br> <li> Preserve initial account index as <code>0</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/bitcold/pull/20/files#diff-4e51445f7140665dfd60e1a5aa87e0fc3580e4b8851d09b166b5a5a41a8e3c0f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

