### PR TITLE
feat: handle exit code correctly

### DIFF
--- a/src/cli/utils/error-handler.mts
+++ b/src/cli/utils/error-handler.mts
@@ -11,6 +11,7 @@ export function withErrorHandler<T extends (...args: any[]) => Promise<void>>(ac
       } else {
         printer.error((e as any)?.message ?? 'Unknown error occurred');
       }
+      process.exitCode = 1
     }
   }) as T;
 }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Set non-zero exit code on CLI errors

- Preserve existing error message printing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CLI action throws error"]
  B["Error handler prints message"]
  C["process.exitCode = 1"]
  A -- "caught by" --> B
  B -- "then sets" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>error-handler.mts</strong><dd><code>Signal failure after handled CLI errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/cli/utils/error-handler.mts

<ul><li>Set <code>process.exitCode = 1</code> inside the catch block<br> <li> Ensure handled CLI failures signal an unsuccessful process exit<br> <li> Keep existing error classification and message output unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/bitcold/pull/27/files#diff-7e72eaafe242051a18cded955b26b8485979e8a2a8c0040e532238f96273ce2b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

