### PR TITLE
fix: wallet remove cmd aciton with global error handler

### DIFF
--- a/src/cli/commands/wallet/remove.mts
+++ b/src/cli/commands/wallet/remove.mts
@@ -3,7 +3,8 @@ import prompts from 'prompts'
 import { repositories as repos } from '../../../persistence/repository.mjs';
 import { printer } from '../../output/index.mjs';
 import { ensureCliLevelSecretInitialized } from '../../../env/index.mjs';
-import { CliError } from '../../../error/cli-error.mjs';
+import { CliParameterError } from '../../../error/cli-error.mjs';
+import { withErrorHandler } from '../../utils/error-handler.mjs';
 
 export const walletRemoveCommand = new Command()
   .name('remove')
@@ -12,29 +13,22 @@ export const walletRemoveCommand = new Command()
   .argument('<wallet-alias>', 'Wallet alias')
   .option('-y --yes', 'Skip confirmation')
 
-  .action(async (walletAlias, opts, cmd) => {
-    try {
-      await ensureCliLevelSecretInitialized()
-      const walletData = await repos.wallet.getWallet(walletAlias)
-      if (walletData === undefined) {
-        printer.error(`Wallet with alias '${walletAlias}' not found`);
-        return;
-      }
-
-      if (!opts.yes) {
-        const answer = await prompts({
-          type: 'confirm',
-          name: 'value',
-          message: `Are you sure you want to remove wallet '${walletAlias}' [${walletData.accounts.map(a => a.alias).join(', ')}]?`
-        });
-        if (!answer.value) return;
-      }
-
-      await repos.wallet.remove(walletAlias);
-      printer.info(`Wallet '${walletAlias}' removed`);
-    } catch (e: unknown) {
-      if (e instanceof CliError) {
-        printer.error(e.message)
-      }
+  .action(withErrorHandler(async (walletAlias, opts, cmd) => {
+    await ensureCliLevelSecretInitialized()
+    const walletData = await repos.wallet.getWallet(walletAlias)
+    if (walletData === undefined) {
+      throw new CliParameterError(`Wallet with alias '${walletAlias}' not found`);
     }
-  })
+
+    if (!opts.yes) {
+      const answer = await prompts({
+        type: 'confirm',
+        name: 'value',
+        message: `Are you sure you want to remove wallet '${walletAlias}' [${walletData.accounts.map(a => a.alias).join(', ')}]?`
+      });
+      if (!answer.value) return;
+    }
+
+    await repos.wallet.remove(walletAlias);
+    printer.info(`Wallet '${walletAlias}' removed`);
+  }))


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Use global CLI error handling

- Wrap `wallet remove` action safely

- Preserve confirmation and deletion flow


___

### Diagram Walkthrough


```mermaid
flowchart LR
  remove["wallet remove command"]
  handler["global withErrorHandler wrapper"]
  flow["remove wallet execution"]
  output["CLI error or success output"]
  remove -- "wraps action with" --> handler
  handler -- "executes" --> flow
  flow -- "reports through" --> output
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>remove.mts</strong><dd><code>Apply global error handling to wallet removal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/cli/commands/wallet/remove.mts

<ul><li>Import <code>withErrorHandler</code> for command execution<br> <li> Wrap the <code>.action(...)</code> callback globally<br> <li> Keep wallet lookup, confirmation, and removal logic<br> <li> Rely on centralized error handling instead of local catch</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/bitcold/pull/28/files#diff-929f6ed2be89ac2668ea97596e76c84f614e81b9af9512edb1c7e958fc4f16d3">+19/-24</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

