### PR TITLE
feat: add transaction preview before signing

### DIFF
--- a/src/cli/commands/tx/sign.mts
+++ b/src/cli/commands/tx/sign.mts
@@ -1,7 +1,8 @@
 import QRCode from 'qrcode'
 import { Command } from 'commander'
+import prompts from 'prompts'
 import { printer } from '../../output/index.mjs'
-import { ensureCliLevelSecretInitialized } from '../../../env/index.mjs'
+import { ensureCliLevelSecretInitialized, getBtcNetwork } from '../../../env/index.mjs'
 import { CliError } from '../../../error/cli-error.mjs'
 import { dereferenceAddress } from '../../utils/wallet-resolver.mjs'
 import { withErrorHandler } from '../../utils/error-handler.mjs'
@@ -17,6 +18,7 @@ interface TxSignParameters {
   fee: string
 
   utxo?: string[]
+  yes?: boolean
 
 }
 
@@ -28,7 +30,14 @@ interface CheckedTxSignParameters {
   fee: number
 
   utxos: { hash: string, index: number, value: number }[]
+  yes: boolean
 
+}
+
+interface ResolvedSenderAddress {
+  ref: string
+  path: string
+  address: BtcAddress
 }
 
 export const txSignCommand = new Command()
@@ -44,23 +53,38 @@ export const txSignCommand = new Command()
     list.push(value)
     return list
   }, [] as string[])
+  .option('-y --yes', 'Skip confirmation after transaction preview', false)
   .option('--qr', 'Display signed transaction as QR code in terminal')
   .action(withErrorHandler(async (_: TxSignParameters, cmd) => {
     const opts = check(_)
     await ensureCliLevelSecretInitialized()
 
-    const sender: BtcAddress = await resolveAddress(opts.from)
+    const sender = await resolveSenderAddress(opts.from)
     const receiver: string = await resolveRawAddress(opts.to)
+    const totalInput = opts.utxos.reduce((acc, utxo) => acc + utxo.value, 0)
+    const change = totalInput - opts.fee - opts.amount
+
+    showTransactionPreview({ opts, sender, receiver, totalInput, change })
+    if (!opts.yes) {
+      const answer = await prompts({
+        type: 'confirm',
+        name: 'value',
+        message: 'Sign transaction?'
+      })
+      if (answer.value !== true) {
+        return
+      }
+    }
 
     const tx = createTransaction({
-      from: sender,
+      from: sender.address,
       to: receiver,
       amount: opts.amount,
       fee: { sats: opts.fee },
       utxos: opts.utxos
     })
 
-    const signedTx = sender.sign(tx)
+    const signedTx = sender.address.sign(tx)
     const vsize = calcVSizeFromHex(signedTx.hex())
     printer.info('Fee rate: ' + (opts.fee / vsize).toFixed(2) + ' sats/vbyte')
     printer.info('Signed transaction (' + vsize + ' vbytes):')
@@ -74,10 +98,14 @@ export const txSignCommand = new Command()
 
   }))
 
-async function resolveAddress(addressRef: string): Promise<BtcAddress> {
+async function resolveSenderAddress(addressRef: string): Promise<ResolvedSenderAddress> {
   const { account, index } = await dereferenceAddress(addressRef)
   const keypair = account.deriveAddress(0, index)
-  return createBtcAddress(account.alias, keypair.privateKey, keypair.publicKey, keypair.address)
+  return {
+    ref: addressRef,
+    path: keypair.path,
+    address: createBtcAddress(account.alias, keypair.privateKey, keypair.publicKey, keypair.address)
+  }
 }
 
 async function resolveRawAddress(addressOrRef: string): Promise<string> {
@@ -124,7 +152,8 @@ function check(opts: TxSignParameters): CheckedTxSignParameters {
     to: opts.to,
     amount: parseInt(opts.amount),
     fee: parseInt(opts.fee),
-    utxos
+    utxos,
+    yes: opts.yes === true
   }
 }
 
@@ -146,4 +175,36 @@ function parseUtxo(raw: string): { hash: string, index: number, value: number } 
   }
 
   return { hash, index: parseInt(indexStr), value: parseInt(valueStr) }
+}
+
+function showTransactionPreview(
+  { opts, sender, receiver, totalInput, change }: {
+    opts: CheckedTxSignParameters
+    sender: ResolvedSenderAddress
+    receiver: string
+    totalInput: number
+    change: number
+  }
+) {
+  printer.info('Transaction preview:')
+  printer.info(`  network ${networkName()}`)
+  printer.info(`  from    ${sender.address.address} (${sender.path})`)
+  printer.info(`  to      ${receiver}`)
+  printer.info(`  amount  ${opts.amount} sats`)
+  printer.info(`  fee     ${opts.fee} sats`)
+  printer.info(`  input   ${totalInput} sats`)
+  printer.info(`  change  ${change} sats${change > 0 ? ' -> ' + sender.address.address : ''}`)
+  printer.info('  utxos')
+  opts.utxos.forEach((utxo, i) => {
+    printer.info(`    ${i} ${utxo.hash}:${utxo.index} ${utxo.value} sats`)
+  })
+  printer.info('')
+}
+
+function networkName(): string {
+  const network = getBtcNetwork()
+  if (network.bech32 === 'bc') return 'mainnet'
+  if (network.bech32 === 'tb') return 'testnet'
+  if (network.bech32 === 'bcrt') return 'regtest'
+  return network.bech32 ?? 'unknown'
 }

--- a/tests/e2e/wallet-lifecycle.test.ts
+++ b/tests/e2e/wallet-lifecycle.test.ts
@@ -272,7 +272,8 @@ describe('Bitcold E2E – Security & Cryptographic Truth', () => {
         '--to', 'bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080',
         '--amount', '1000',
         '--fee', '200',
-        '--utxo', dummyUtxo
+        '--utxo', dummyUtxo,
+        '--yes'
       ], { BITCOLD_PASSPHRASE: CLI_PASS });
 
       await s.waitFor('mnemonic passphrase');
@@ -280,6 +281,8 @@ describe('Bitcold E2E – Security & Cryptographic Truth', () => {
       const r = await s.finish();
       
       expect(r.exitCode).toBe(0);
+      expect(r.output).toContain('Transaction preview:');
+      expect(r.output).toContain('  change  3800 sats -> ');
       const txHex = r.output.match(/[0-9a-f]{100,}/i)?.[0];
       expect(txHex).toBeDefined();
       expect(txHex).toMatch(/^(01|02)000000/); // Version
@@ -297,7 +300,8 @@ describe('Bitcold E2E – Security & Cryptographic Truth', () => {
         '--to', 'bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu',
         '--amount', '5000',
         '--fee', '1000',
-        '--utxo', dummyUtxo
+        '--utxo', dummyUtxo,
+        '--yes'
       ], { 
         BITCOLD_PASSPHRASE: CLI_PASS,
         BITCOLD_BITCOIN_NETWORK: 'mainnet'
@@ -308,6 +312,7 @@ describe('Bitcold E2E – Security & Cryptographic Truth', () => {
       const r = await s.finish();
       
       expect(r.exitCode).toBe(0);
+      expect(r.output).toContain('Transaction preview:');
       expect(r.output).toContain('Signed transaction');
       expect(r.output).toMatch(/[0-9a-f]{200,}/);
     }, 35000);


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Add transaction preview before signing

- Require confirmation unless `--yes` provided

- Show network, change, and UTXOs

- Update E2E signing expectations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["tx sign command"] 
  B["Resolve sender and receiver"]
  C["Display transaction preview"]
  D["Prompt for confirmation"]
  E["Create and sign transaction"]
  F["Print signed transaction"]

  A -- "inputs" --> B
  B -- "details" --> C
  C -- "unless --yes" --> D
  D -- "confirmed" --> E
  C -- "--yes" --> E
  E -- "hex output" --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sign.mts</strong><dd><code>Preview and confirm transactions before signing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/cli/commands/tx/sign.mts

<ul><li>Adds <code>--yes</code> to skip preview confirmation.<br> <li> Displays a transaction preview with network, sender path, recipient, <br>amounts, change, and UTXOs.<br> <li> Prompts users to confirm signing via <code>prompts</code>.<br> <li> Tracks resolved sender metadata separately from <code>BtcAddress</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/bitcold/pull/32/files#diff-4023c72f69a1f11cc6e5cebc0d31d5a62966231743b05c9b116efde5c3facce8">+68/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>wallet-lifecycle.test.ts</strong><dd><code>Cover transaction preview in signing tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/e2e/wallet-lifecycle.test.ts

<ul><li>Passes <code>--yes</code> in signing E2E flows.<br> <li> Verifies transaction preview output appears.<br> <li> Checks expected change output for regtest signing.</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/bitcold/pull/32/files#diff-2ccba3dc92e847d94f995e5f110a60261cfd7e4fff8752f565964fb13812e3df">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

