### PR TITLE
feat: support entropy input formats

### DIFF
--- a/src/cli/commands/wallet/create.mts
+++ b/src/cli/commands/wallet/create.mts
@@ -15,7 +15,7 @@ interface WalletCreateParams {
   mnemonicLength: number
   passphrase?: string
   showMnemonic?: boolean
-  entropyBits?: string
+  entropy?: string
 }
 
 export const walletCreateCommand = new Command()
@@ -27,7 +27,7 @@ export const walletCreateCommand = new Command()
   .option<number>('-l --mnemonic-length <length> ', 'Length of the mnemonic you want to generate', length => parseInt(length), 12)
   .option('-p --passphrase <passphrase>', 'Passphrase for the mnemonic (never saved, used for derivation preview only)')
   .option('-s --show-mnemonic', 'Show the mnemonic after creating the wallet', false)
-  .option('-b --entropy-bits <bits>', 'Entropy bits for the wallet, receive 128, 160, 192, 224, 256 bits')
+  .option('-e --entropy <entropy>', 'Entropy for the wallet, use hex (0x...) or binary (0b...), 128/160/192/224/256 bits')
 
   .action(withErrorHandler(async (alias: string | undefined, opts: WalletCreateParams) => {
     if (alias) {
@@ -35,13 +35,13 @@ export const walletCreateCommand = new Command()
     }
     await ensureCliLevelSecretInitialized()
     fix(opts)
-    check(opts); assert(opts.entropyBits != undefined || isValidMnemonicLength(opts.mnemonicLength))
+    check(opts); assert(opts.entropy != undefined || isValidMnemonicLength(opts.mnemonicLength))
 
     const walletName = opts.alias ?? await generateNextWalletName()
     await checkNameUnique(opts, walletName);
 
     const mnemonic = {
-      words: opts.mnemonic ?? mnemonicUtil.generate(toBuffer(opts.entropyBits) as Buffer | undefined ?? opts.mnemonicLength as 12 | 15 | 18 | 21 | 24),
+      words: opts.mnemonic ?? mnemonicUtil.generate(toEntropyBuffer(opts.entropy) as Buffer | undefined ?? opts.mnemonicLength as 12 | 15 | 18 | 21 | 24),
       passphrase: opts.passphrase
     }
 
@@ -63,11 +63,16 @@ async function checkNameUnique(opts: WalletCreateParams, walletName: string) {
   }
 }
 
-function toBuffer(bits?: string): Buffer | undefined {
-  if (bits == undefined) {
+function toEntropyBuffer(entropy?: string): Buffer | undefined {
+  if (entropy == undefined) {
     return undefined
   }
 
+  if (/^0x[0-9a-f]+$/i.test(entropy)) {
+    return Buffer.from(entropy.slice(2), 'hex')
+  }
+
+  const bits = entropy.slice(2)
   const byteLength = bits.length / 8
   const buffer = Buffer.alloc(byteLength)
   for (let i = 0; i < byteLength; i++) {
@@ -79,8 +84,8 @@ function toBuffer(bits?: string): Buffer | undefined {
 function check(opts: WalletCreateParams) {
   checkWalletAlias(opts.alias)
   checkMnemonic(opts.mnemonic)
-  if (opts.entropyBits != undefined) {
-    checkEntropyBits(opts.entropyBits)
+  if (opts.entropy != undefined) {
+    checkEntropy(opts.entropy)
   } else {
     checkMnemonicLengthToGenerate(opts.mnemonicLength)
   }
@@ -106,13 +111,14 @@ function checkMnemonic(mnemonic: string | undefined) {
   }
 }
 
-function checkEntropyBits(entropyBits: string) {
+function checkEntropy(entropy: string) {
   const validBits = [128, 160, 192, 224, 256]
-  if (!validBits.includes(entropyBits.length)) {
-    throw new CliParameterError('entropy bits should be one of ' + validBits.join(', '))
+  const bits = entropyBitLength(entropy)
+  if (bits === undefined) {
+    throw new CliParameterError('entropy should use hex (0x...) or binary (0b...) format')
   }
-  if (!entropyBits.match(/^[01]+$/)) {
-    throw new CliParameterError('entropy bits should be a binary string containing only 0 and 1')
+  if (!validBits.includes(bits)) {
+    throw new CliParameterError('entropy should be one of ' + validBits.join(', ') + ' bits')
   }
 }
 
@@ -140,4 +146,20 @@ function fix(opts: WalletCreateParams) {
   if (typeof opts.mnemonic === 'string') {
     opts.mnemonic = ensureSingleWhiteSpace(opts.mnemonic.trim())
   }
+
+  if (typeof opts.entropy === 'string') {
+    opts.entropy = opts.entropy.trim()
+  }
+}
+
+function entropyBitLength(entropy: string): number | undefined {
+  if (/^0x[0-9a-f]+$/i.test(entropy)) {
+    return (entropy.length - 2) * 4
+  }
+
+  if (/^0b[01]+$/i.test(entropy)) {
+    return entropy.length - 2
+  }
+
+  return undefined
 }

--- a/src/cli/commands/wallet/show.mts
+++ b/src/cli/commands/wallet/show.mts
@@ -5,8 +5,14 @@ import { repositories as repos } from '../../../persistence/repository.mjs';
 import { printer } from '../../output/index.mjs';
 import { ensureCliLevelSecretInitialized } from '../../../env/index.mjs';
 import { loadWalletWithBip39PassphrasePrompt, dereferenceAddress } from '../../utils/wallet-resolver.mjs';
-import { getAccountPath } from '../../../crypto/mnemonic.mjs';
+import { entropyHexOf, getAccountPath } from '../../../crypto/mnemonic.mjs';
 import { xpubkeySummary } from '../../../utils/display.mjs';
+
+interface WalletShowOptions {
+  mnemonic: boolean
+  private?: boolean
+  entropy?: boolean
+}
 
 export const walletShowCommand = new Command()
   .name('show')
@@ -15,8 +21,9 @@ export const walletShowCommand = new Command()
   .argument('<alias-or-address-ref>', 'Wallet alias or wallet@account:index reference')
   .option('-p --private', 'Show private keys')
   .option('-m --mnemonic', 'Show mnemonic')
+  .option('--entropy', 'Show wallet mnemonic entropy as hexadecimal')
 
-  .action(withErrorHandler(async (ref, opts) => {
+  .action(withErrorHandler(async (ref, opts: WalletShowOptions) => {
     await ensureCliLevelSecretInitialized()
 
     const isAddressRef = ref.includes(':')
@@ -26,6 +33,7 @@ export const walletShowCommand = new Command()
 
       printer.info(`Wallet: ${wallet.alias}`)
       if (opts.mnemonic) printer.info(`Mnemonic: ${wallet.mnemonic.words}`);
+      if (opts.entropy) printer.info(`Entropy: 0x${entropyHexOf(wallet.mnemonic.words)}`);
       printer.info(`Account: ${account.alias}`)
       printer.info(`  path    ${derived.path}`)
       printer.info(`  address ${derived.address}`)
@@ -55,9 +63,10 @@ export const walletShowCommand = new Command()
   }))
 
 
-export function show(wallet: Wallet, opts: { mnemonic: boolean, private?: boolean }) {
+export function show(wallet: Wallet, opts: WalletShowOptions) {
   printer.info(`Wallet: ${wallet.alias}`);
   if (opts.mnemonic) printer.info(`Mnemonic: ${wallet.mnemonic.words}`);
+  if (opts.entropy) printer.info(`Entropy: 0x${entropyHexOf(wallet.mnemonic.words)}`);
   [...wallet.accounts.entries()].forEach(([alias, account]) => {
     printer.info(`  ${alias}`)
     printer.info(`    path  ${getAccountPath(account.accountIndex)}`)

--- a/src/crypto/mnemonic.mts
+++ b/src/crypto/mnemonic.mts
@@ -39,6 +39,10 @@ export function generate(
   return mnemoniclib.generateMnemonic(strength)
 }
 
+export function entropyHexOf(mnemonic: string): string {
+  return mnemoniclib.mnemonicToEntropy(mnemonic)
+}
+
 export function derive(mnemonic: Mnemonic, accountIndex: number, change: number, index: number): {
   privateKey: { hex: string; wif: string }
   publicKey: string

--- a/tests/e2e/wallet-lifecycle.test.ts
+++ b/tests/e2e/wallet-lifecycle.test.ts
@@ -120,8 +120,8 @@ describe('Bitcold E2E – Security & Cryptographic Truth', () => {
       expect(addr).toBe(TRUTH_SET_2.regtest);
     }, 30000);
 
-    it('Entropy: 128-bit bits -> mnemonic (Truth Set 1)', async () => {
-      sandbox.run(['wallet', 'create', 'e1-wallet', '-b', TRUTH_SET_1.entropy, '-s'], {
+    it('Entropy: 128-bit binary -> mnemonic (Truth Set 1)', async () => {
+      sandbox.run(['wallet', 'create', 'e1-wallet', '--entropy', '0b' + TRUTH_SET_1.entropy, '-s'], {
         BITCOLD_PASSPHRASE: CLI_PASS
       });
       const r = await sandbox.finish();
@@ -129,13 +129,34 @@ describe('Bitcold E2E – Security & Cryptographic Truth', () => {
       expect(normalizedOutput).toContain(TRUTH_SET_1.mnemonic);
     }, 30000);
 
-    it('Entropy: 128-bit bits -> mnemonic (Truth Set 2)', async () => {
-      sandbox.run(['wallet', 'create', 'e2-wallet', '-b', TRUTH_SET_2.entropy, '-s'], {
+    it('Entropy: 128-bit hex -> mnemonic (Truth Set 1)', async () => {
+      sandbox.run(['wallet', 'create', 'e1-hex-wallet', '-e', '0x' + '0'.repeat(32), '-s'], {
+        BITCOLD_PASSPHRASE: CLI_PASS
+      });
+      const r = await sandbox.finish();
+      const normalizedOutput = r.output.replace(/\s+/g, ' ');
+      expect(normalizedOutput).toContain(TRUTH_SET_1.mnemonic);
+    }, 30000);
+
+    it('Entropy: 128-bit binary -> mnemonic (Truth Set 2)', async () => {
+      sandbox.run(['wallet', 'create', 'e2-wallet', '--entropy', '0b' + TRUTH_SET_2.entropy, '-s'], {
         BITCOLD_PASSPHRASE: CLI_PASS
       });
       const r = await sandbox.finish();
       const normalizedOutput = r.output.replace(/\s+/g, ' ');
       expect(normalizedOutput).toContain(TRUTH_SET_2.mnemonic);
+    }, 30000);
+
+    it('Show entropy: displays wallet entropy as hex', async () => {
+      await createWallet(sandbox.sandboxDir, 'entropy-wallet', TRUTH_SET_1.mnemonic);
+
+      const s = reuseDir(sandbox.sandboxDir);
+      s.run(['wallet', 'show', 'entropy-wallet', '--entropy'], { BITCOLD_PASSPHRASE: CLI_PASS });
+      await s.waitFor('mnemonic passphrase');
+      await s.type('\r');
+      const r = await s.finish();
+
+      expect(r.output).toContain('Entropy: 0x' + '0'.repeat(32));
     }, 30000);
   });
 


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Add prefixed entropy input support

- Support hex entropy during wallet creation

- Display mnemonic entropy in wallet show

- Cover entropy flows with E2E tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  create["wallet create"]
  parse["Parse 0x/0b entropy"]
  mnemonic["Generate mnemonic"]
  show["wallet show --entropy"]
  hex["Display entropy hex"]

  create -- "accepts --entropy" --> parse
  parse -- "feeds buffer" --> mnemonic
  show -- "converts mnemonic" --> hex
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>wallet-lifecycle.test.ts</strong><dd><code>Add E2E coverage for entropy formats</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/e2e/wallet-lifecycle.test.ts

<ul><li>Updates entropy creation tests to use <code>--entropy</code>.<br> <li> Adds binary entropy coverage with <code>0b</code> prefix.<br> <li> Adds hex entropy coverage with <code>0x</code> prefix.<br> <li> Verifies <code>wallet show --entropy</code> outputs hex entropy.</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/bitcold/pull/33/files#diff-2ccba3dc92e847d94f995e5f110a60261cfd7e4fff8752f565964fb13812e3df">+25/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create.mts</strong><dd><code>Support formatted entropy for wallet creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/cli/commands/wallet/create.mts

<ul><li>Replaces <code>--entropy-bits</code> with <code>--entropy</code>.<br> <li> Accepts entropy in <code>0x...</code> or <code>0b...</code> format.<br> <li> Converts validated entropy into a mnemonic buffer.<br> <li> Adds validation and trimming for formatted entropy.</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/bitcold/pull/33/files#diff-197dd55d863d425d14393b15114da254ef18e29afb9634675f39b6c4c49fb8ad">+35/-13</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>show.mts</strong><dd><code>Add entropy display to wallet show</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/cli/commands/wallet/show.mts

<ul><li>Adds <code>--entropy</code> option for wallet details.<br> <li> Prints entropy as <code>0x</code>-prefixed hexadecimal.<br> <li> Supports entropy display for wallet references.<br> <li> Adds typed options for show command handling.</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/bitcold/pull/33/files#diff-426183024af0f3b03185403a18b11f1910b76318441365ae07603c3d5a6ab079">+12/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mnemonic.mts</strong><dd><code>Expose mnemonic entropy conversion helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/crypto/mnemonic.mts

<ul><li>Adds <code>entropyHexOf</code> helper.<br> <li> Converts mnemonic words back to BIP39 entropy.<br> <li> Exposes entropy conversion for CLI display.</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/bitcold/pull/33/files#diff-3deacb47b88045ff54e9ed7b8910f889fc7488b09492ffb8b4cb68230ca32465">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

