### PR TITLE
feat: add show entropy short option

### DIFF
--- a/src/cli/commands/wallet/show.mts
+++ b/src/cli/commands/wallet/show.mts
@@ -21,7 +21,7 @@ export const walletShowCommand = new Command()
   .argument('<alias-or-address-ref>', 'Wallet alias or wallet@account:index reference')
   .option('-p --private', 'Show private keys')
   .option('-m --mnemonic', 'Show mnemonic')
-  .option('--entropy', 'Show wallet mnemonic entropy as hexadecimal')
+  .option('-e --entropy', 'Show wallet mnemonic entropy as hexadecimal')
 
   .action(withErrorHandler(async (ref, opts: WalletShowOptions) => {
     await ensureCliLevelSecretInitialized()

--- a/tests/e2e/wallet-lifecycle.test.ts
+++ b/tests/e2e/wallet-lifecycle.test.ts
@@ -151,7 +151,7 @@ describe('Bitcold E2E – Security & Cryptographic Truth', () => {
       await createWallet(sandbox.sandboxDir, 'entropy-wallet', TRUTH_SET_1.mnemonic);
 
       const s = reuseDir(sandbox.sandboxDir);
-      s.run(['wallet', 'show', 'entropy-wallet', '--entropy'], { BITCOLD_PASSPHRASE: CLI_PASS });
+      s.run(['wallet', 'show', 'entropy-wallet', '-e'], { BITCOLD_PASSPHRASE: CLI_PASS });
       await s.waitFor('mnemonic passphrase');
       await s.type('\r');
       const r = await s.finish();


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Add `-e` entropy shortcut

- Keep entropy display test covered


___

### Diagram Walkthrough


```mermaid
flowchart LR
  cli["wallet show CLI"] -- "adds -e alias" --> entropy["--entropy option"]
  test["E2E wallet test"] -- "uses shortcut" --> cli
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>show.mts</strong><dd><code>Add short entropy CLI option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/cli/commands/wallet/show.mts

<ul><li>Adds <code>-e</code> as a short alias for <code>--entropy</code>.<br> <li> Preserves existing wallet entropy display behavior.</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/bitcold/pull/35/files#diff-426183024af0f3b03185403a18b11f1910b76318441365ae07603c3d5a6ab079">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>wallet-lifecycle.test.ts</strong><dd><code>Cover entropy shortcut in E2E test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/e2e/wallet-lifecycle.test.ts

<ul><li>Updates the entropy display E2E test.<br> <li> Verifies <code>wallet show</code> accepts the new <code>-e</code> shortcut.</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/bitcold/pull/35/files#diff-2ccba3dc92e847d94f995e5f110a60261cfd7e4fff8752f565964fb13812e3df">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

