### PR TITLE
fix: show entropy before mnemonic

### DIFF
--- a/src/cli/commands/wallet/show.mts
+++ b/src/cli/commands/wallet/show.mts
@@ -32,8 +32,8 @@ export const walletShowCommand = new Command()
       const derived = account.deriveAddress(0, index)
 
       printer.info(`Wallet: ${wallet.alias}`)
-      if (opts.mnemonic) printer.info(`Mnemonic: ${wallet.mnemonic.words}`);
       if (opts.entropy) printer.info(`Entropy: 0x${entropyHexOf(wallet.mnemonic.words)}`);
+      if (opts.mnemonic) printer.info(`Mnemonic: ${wallet.mnemonic.words}`);
       printer.info(`Account: ${account.alias}`)
       printer.info(`  path    ${derived.path}`)
       printer.info(`  address ${derived.address}`)
@@ -65,8 +65,8 @@ export const walletShowCommand = new Command()
 
 export function show(wallet: Wallet, opts: WalletShowOptions) {
   printer.info(`Wallet: ${wallet.alias}`);
-  if (opts.mnemonic) printer.info(`Mnemonic: ${wallet.mnemonic.words}`);
   if (opts.entropy) printer.info(`Entropy: 0x${entropyHexOf(wallet.mnemonic.words)}`);
+  if (opts.mnemonic) printer.info(`Mnemonic: ${wallet.mnemonic.words}`);
   [...wallet.accounts.entries()].forEach(([alias, account]) => {
     printer.info(`  ${alias}`)
     printer.info(`    path  ${getAccountPath(account.accountIndex)}`)

--- a/tests/e2e/wallet-lifecycle.test.ts
+++ b/tests/e2e/wallet-lifecycle.test.ts
@@ -147,16 +147,18 @@ describe('Bitcold E2E – Security & Cryptographic Truth', () => {
       expect(normalizedOutput).toContain(TRUTH_SET_2.mnemonic);
     }, 30000);
 
-    it('Show entropy: displays wallet entropy as hex', async () => {
+    it('Show entropy: displays wallet entropy before mnemonic', async () => {
       await createWallet(sandbox.sandboxDir, 'entropy-wallet', TRUTH_SET_1.mnemonic);
 
       const s = reuseDir(sandbox.sandboxDir);
-      s.run(['wallet', 'show', 'entropy-wallet', '-e'], { BITCOLD_PASSPHRASE: CLI_PASS });
+      s.run(['wallet', 'show', 'entropy-wallet', '-e', '-m'], { BITCOLD_PASSPHRASE: CLI_PASS });
       await s.waitFor('mnemonic passphrase');
       await s.type('\r');
       const r = await s.finish();
 
-      expect(r.output).toContain('Entropy: 0x' + '0'.repeat(32));
+      const entropyLine = 'Entropy: 0x' + '0'.repeat(32);
+      expect(r.output).toContain(entropyLine);
+      expect(r.output.indexOf(entropyLine)).toBeLessThan(r.output.indexOf('Mnemonic: ' + TRUTH_SET_1.mnemonic));
     }, 30000);
   });
 


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Print entropy before mnemonic

- Cover combined entropy and mnemonic display


___

### Diagram Walkthrough


```mermaid
flowchart LR
  walletShow["wallet show command"]
  entropy["Entropy output"]
  mnemonic["Mnemonic output"]
  test["E2E ordering test"]
  walletShow -- "prints first" --> entropy
  entropy -- "then prints" --> mnemonic
  test -- "verifies order" --> walletShow
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>show.mts</strong><dd><code>Print entropy before mnemonic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/cli/commands/wallet/show.mts

<ul><li>Reorders wallet display output.<br> <li> Prints <code>Entropy:</code> before <code>Mnemonic:</code> when both flags are used.<br> <li> Applies ordering to wallet and address-reference views.</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/bitcold/pull/36/files#diff-426183024af0f3b03185403a18b11f1910b76318441365ae07603c3d5a6ab079">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>wallet-lifecycle.test.ts</strong><dd><code>Verify entropy precedes mnemonic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/e2e/wallet-lifecycle.test.ts

<ul><li>Updates entropy display E2E test name.<br> <li> Runs <code>wallet show</code> with <code>-e</code> and <code>-m</code>.<br> <li> Asserts entropy appears before mnemonic.</ul>


</details>


  </td>
  <td><a href="https://github.com/Drincann/bitcold/pull/36/files#diff-2ccba3dc92e847d94f995e5f110a60261cfd7e4fff8752f565964fb13812e3df">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

